### PR TITLE
Implement parts of java.util.logging

### DIFF
--- a/src/main/scala/java/util/logging/ConsoleHandler.scala
+++ b/src/main/scala/java/util/logging/ConsoleHandler.scala
@@ -1,0 +1,16 @@
+package java.util.logging
+
+// Unfortunately the spec require the use of System.err
+class ConsoleHandler extends StreamHandler(System.err, new SimpleFormatter) {
+
+  // Overriden on the javadocs but there are no comments about differences
+  override def publish(record: LogRecord): Unit =
+    super.publish(record)
+
+  override def close(): Unit = {
+    // Required by javadocs not to close the stream
+    writeHeader()
+    writeTail()
+    flush()
+  }
+}

--- a/src/main/scala/java/util/logging/ErrorManager.scala
+++ b/src/main/scala/java/util/logging/ErrorManager.scala
@@ -1,0 +1,30 @@
+package java.util.logging
+
+object ErrorManager {
+  val GENERIC_FAILURE = 0
+  val WRITE_FAILURE = 1
+  val FLUSH_FAILURE = 2
+  val CLOSE_FAILURE = 3
+  val OPEN_FAILURE = 4
+  val FORMAT_FAILURE = 5
+}
+
+class ErrorManager() {
+
+  // The spec is a bit vague. This will implement the most
+  // obvious interpretation of outputting only once
+  private[this] var called = false
+
+  def error(msg: String, ex: Exception, code: Int): Unit = {
+    if (!called) {
+      // The format is undocumented, this is learned by runtime experimentation
+      if (msg == null && ex == null) {
+        System.err.println(code)
+      } else {
+        System.err.println(s"$code: $msg")
+        if (ex == null) ex.printStackTrace(System.err)
+      }
+      called = true
+    }
+  }
+}

--- a/src/main/scala/java/util/logging/Filter.scala
+++ b/src/main/scala/java/util/logging/Filter.scala
@@ -1,0 +1,5 @@
+package java.util.logging
+
+trait Filter {
+  def isLoggable(record: LogRecord): Boolean
+}

--- a/src/main/scala/java/util/logging/Formatter.scala
+++ b/src/main/scala/java/util/logging/Formatter.scala
@@ -1,0 +1,71 @@
+package java.util.logging
+
+abstract class Formatter protected () {
+
+  def format(record: LogRecord): String
+
+  def getHead(h: Handler): String = ""
+
+  def getTail(h: Handler): String = ""
+
+  def formatMessage(record: LogRecord): String = {
+    val msg = record.getMessage
+    val params = record.getParameters
+
+    if (params != null && params.length > 0) {
+      // The Java spec uses java.text formatting not available in Scala.js
+      // Instead we'll do simple text replacement, very imperative
+      var msgAccumulator = new StringBuilder()
+      var inParam = false
+      var paramInFlight:StringBuilder = null
+      var substitutionFailure = false // track failure to break the loop
+      var i = 0
+
+      // Do one run over msg keeping track if a param needs replacement
+      while (i < msg.length && !substitutionFailure) {
+        val currentChar = msg.charAt(i)
+        i = i + 1
+        if (currentChar == '{' && !inParam) {
+          // Beginning of param
+          inParam = true
+          paramInFlight = new StringBuilder()
+        } else if (inParam && currentChar != '}') {
+          // accumulate the param
+          paramInFlight += currentChar
+        } else if (currentChar == '}') {
+          // end of param, replace placeholder by value if possible
+          inParam = false
+          val (failed, replacement) = {
+            try {
+              val index = paramInFlight.toInt
+              if (index >= 0 && index < params.length) {
+                (false, params(index).toString)
+              } else if (index > 0) {
+                (false, "{" + index + "}")
+              } else {
+                // Negative indexes break substitution on the JVM
+                (true, "")
+              }
+            } catch {
+              case e: Exception =>
+                // The JVM will halt replacing if it cannot parse one param
+                (true, "")
+            }
+          }
+
+          // The JVM will fail if e.g. there are bogus params and would not replace
+          // any parameter
+          if (failed) substitutionFailure = failed
+          else msgAccumulator ++= replacement
+        } else {
+          msgAccumulator += currentChar
+        }
+      }
+
+      if (substitutionFailure || inParam) msg
+      else msgAccumulator.result()
+    } else {
+      msg
+    }
+  }
+}

--- a/src/main/scala/java/util/logging/Handler.scala
+++ b/src/main/scala/java/util/logging/Handler.scala
@@ -1,0 +1,54 @@
+package java.util.logging
+
+import java.nio.charset.{Charset, UnsupportedCharsetException}
+
+abstract class Handler protected () {
+
+  private[this] var level: Level = Level.ALL
+  private[this] var filter: Filter = null
+  private[this] var formatter: Formatter = null
+  private[this] var encoding: String = null
+  private[this] var errorManager: ErrorManager = new ErrorManager()
+
+  def publish(record:LogRecord): Unit
+
+  def flush(): Unit
+
+  def close(): Unit
+
+  def setFormatter(formatter: Formatter): Unit = this.formatter = formatter
+
+  def getFormatter(): Formatter = formatter
+
+  def setEncoding(encoding: String): Unit = {
+    if (encoding == null) this.encoding = null
+    else if (Charset.isSupported(encoding)) this.encoding = encoding
+    else throw new UnsupportedCharsetException(s"$encoding not supported")
+  }
+
+  def getEncoding(): String = encoding
+
+  def setFilter(filter: Filter): Unit = this.filter = filter
+
+  def getFilter(): Filter = filter
+
+  def setErrorManager(errorManager: ErrorManager): Unit =
+    if (errorManager == null) throw new NullPointerException()
+    else this.errorManager = errorManager
+
+  def getErrorManager(): ErrorManager = errorManager
+
+  protected def reportError(msg: String, ex: Exception, code: Int): Unit =
+    errorManager.error(msg, ex, code)
+
+  def setLevel(level: Level): Unit =
+    if (level == null) throw new NullPointerException()
+    else this.level = level
+
+  def getLevel(): Level = level
+
+  def isLoggable(record:LogRecord): Boolean = {
+    level.intValue() <= record.getLevel.intValue() &&
+    (filter == null || filter.isLoggable(record))
+  }
+}

--- a/src/main/scala/java/util/logging/Level.scala
+++ b/src/main/scala/java/util/logging/Level.scala
@@ -1,0 +1,51 @@
+package java.util.logging
+
+object Level {
+
+  val OFF: Level = new Level("OFF", Int.MaxValue)
+  val SEVERE: Level = new Level("SEVERE", 1000)
+  val WARNING: Level = new Level("WARNING", 900)
+  val INFO: Level = new Level("INFO", 800)
+  val CONFIG: Level = new Level("CONFIG", 700)
+  val FINE: Level = new Level("FINE", 500)
+  val FINER: Level = new Level("FINER", 400)
+  val FINEST: Level = new Level("FINEST", 300)
+  val ALL: Level = new Level("ALL", Int.MinValue)
+
+  private lazy val knownLevels = Map[String, Level](OFF.getName -> OFF,
+      SEVERE.getName -> SEVERE, WARNING.getName -> WARNING,
+      INFO.getName -> INFO, CONFIG.getName -> CONFIG, FINE.getName -> FINE,
+      FINER.getName -> FINER, FINEST.getName -> FINEST, ALL.getName -> ALL)
+
+  def parse(name: String): Level =
+    if (name == null) throw new NullPointerException("Name cannot be null")
+    else knownLevels.getOrElse(name, throw new IllegalArgumentException(""))
+}
+
+class Level protected (private[this] val name: String,
+    private[this] val value: Int,
+    private[this] val resourceBundleName: String) {
+
+  if (name == null)
+    throw new NullPointerException("Name cannot be null")
+
+  protected def this(name: String, value: Int) = this(name, value, null)
+
+  def getResourceBundleName(): String = resourceBundleName
+
+  def getName(): String = name
+
+  // Not implemented, no locale in Scala.js
+  //def getLocalizedName():String
+
+  override def toString(): String = name
+
+  def intValue(): Int = value
+
+  override def equals(obj: Any): Boolean = obj match {
+    case l: Level => intValue() == l.intValue()
+    case _        => false
+  }
+
+  override def hashCode(): Int = value
+}

--- a/src/main/scala/java/util/logging/LogRecord.scala
+++ b/src/main/scala/java/util/logging/LogRecord.scala
@@ -1,0 +1,76 @@
+package java.util.logging
+
+object LogRecord {
+  protected[logging] var sequence: Long = 0L
+}
+
+class LogRecord(private[this] var level: Level, private[this] var msg: String) {
+
+  private[this] var sourceClassName: String = null
+  private[this] var sourceMethodName: String = null
+  private[this] var params: Array[AnyRef] = null
+  private[this] var thrown: Throwable = null
+  private[this] var loggerName: String = null
+  private[this] var millis: Long = System.currentTimeMillis()
+  private[this] var threadId: Long = Thread.currentThread().getId
+
+  private[this] var sequenceNumber: Long = {
+    LogRecord.sequence = LogRecord.sequence + 1
+    LogRecord.sequence
+  }
+
+  def getLoggerName(): String = loggerName
+
+  def setLoggerName(loggerName: String): Unit =
+    this.loggerName = loggerName
+
+  // Not implemented, no locale in Scala.js
+  //def getResourceBundle():ResourceBundle = ???
+
+  // Not implemented, no locale in Scala.js
+  //def setResourceBundle(bundle: ResourceBundle):Unit = ???
+
+  // Message is not localizable, return null
+  def getResourceBundleName(): String = null
+
+  // Message is not localizable, no-op
+  def setResourceBundleName(name: String): Unit = {}
+
+  def getLevel(): Level = level
+
+  def setLevel(level: Level): Unit = this.level = level
+
+  def getSequenceNumber(): Long = sequenceNumber
+
+  def setSequenceNumber(seq: Long): Unit = sequenceNumber = seq
+
+  def getSourceClassName(): String = sourceClassName
+
+  def setSourceClassName(sourceClassName: String): Unit =
+    this.sourceClassName = sourceClassName
+
+  def getSourceMethodName(): String = sourceMethodName
+
+  def setSourceMethodName(sourceClassName: String): Unit =
+    this.sourceMethodName = sourceClassName
+
+  def getMessage(): String = msg
+
+  def setMessage(message: String): Unit = msg = message
+
+  def getParameters(): Array[AnyRef] = params
+
+  def setParameters(parameters: Array[AnyRef]): Unit = this.params = parameters
+
+  def getThreadID(): Int = threadId.toInt
+
+  def setThreadID(threadID: Int): Unit = this.threadId = threadID
+
+  def getMillis(): Long = millis
+
+  def setMillis(millis: Long): Unit = this.millis = millis
+
+  def getThrown(): Throwable = thrown
+
+  def setThrown(thrown: Throwable): Unit = this.thrown = thrown
+}

--- a/src/main/scala/java/util/logging/Logger.scala
+++ b/src/main/scala/java/util/logging/Logger.scala
@@ -1,0 +1,321 @@
+package java.util.logging
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+object Logger {
+
+  val GLOBAL_LOGGER_NAME: String =  "global"
+
+  // Not implemented, deprecated on JDK 1.8
+  //val global: Logger
+
+  private val defaultLogLevel: Level = Level.ALL
+
+  private val loggers: mutable.Map[String, Logger] = mutable.Map.empty
+
+  private def newLogger(name: String): Logger = {
+    val logger = new Logger(name, null)
+    logger.setLevel(null)
+    logger.setUseParentHandlers(true)
+    logger.setParent(rootLogger)
+    logger
+  }
+
+  // Root is not visible to the outside but gives defaults
+  private[this] val rootLogger: Logger = {
+    val l = new Logger("", null)
+    l.setLevel(defaultLogLevel)
+    l.setUseParentHandlers(false)
+    l.setParent(null)
+    l
+  }
+
+  private[this] val globalLogger: Logger = {
+    val l = new Logger(GLOBAL_LOGGER_NAME, null)
+    l.setLevel(defaultLogLevel)
+    l.setUseParentHandlers(true)
+    l.setParent(rootLogger)
+    l
+  }
+
+  def getGlobal(): Logger = globalLogger
+
+  def getLogger(name: String): Logger = {
+    if (name == null)
+      throw new NullPointerException("Logger name cannot be null")
+
+    loggers.getOrElseUpdate(name, newLogger(name))
+  }
+
+  // Not implemented, no resource bundle in scala.js
+  //def getLogger(name: String, resourceBundle: String): Logger
+
+  private[logging] def findParent(logger: Logger): Option[Logger] = {
+    @tailrec
+    def go(s: List[String]): Option[Logger] = s match {
+      case Nil => None
+
+      case b if loggers.contains(b.mkString(".")) =>
+        loggers.get(b.mkString("."))
+
+      case b => go(b.dropRight(1))
+    }
+
+    go(Option(logger.getName).getOrElse("").split("\\.").toList.dropRight(1))
+  }
+
+  def getAnonymousLogger(): Logger = {
+    // No references to anonymous loggers are kept
+    newLogger(null)
+  }
+
+  // Not implemented, no resource bundle in scala.js
+  //def getAnonymousLogger(resourceBundle: String):Logger
+}
+
+class Logger(name: String, resourceBundle: String) {
+
+  private[this] var level: Level = null
+  private[this] var useParentsHandlers: Boolean = false
+  private[this] var parent: Logger = null
+  private[this] var filter: Filter = null
+  private[this] var handlers: Array[Handler] = Array.empty
+
+  // Find the effective level
+  private def levelR: Level = {
+    @tailrec
+    def go(logger: Logger): Level = {
+      if (logger.getLevel != null) logger.getLevel
+      else if (logger.getParent == null) null
+      else go(logger.getParent)
+    }
+
+    go(this)
+  }
+
+  // Not implemented, no resource bundle
+  //def getResourceBundle():ResourceBundle = ???
+
+  def getResourceBundleName(): String = resourceBundle
+
+  def setFilter(filter: Filter): Unit = this.filter = filter
+
+  def getFilter(): Filter = filter
+
+  def log(record: LogRecord): Unit = {
+    if (isLoggable(record.getLevel)) {
+      if (useParentsHandlers) {
+        val parent = getParent()
+        if (parent != null)
+          parent.log(record)
+      }
+      handlers.foreach(_.publish(record))
+    }
+  }
+
+  def log(level: Level, msg: String): Unit = {
+    val r = new LogRecord(level, msg)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def log(level: Level, msg: String, param: AnyRef): Unit = {
+    val r = new LogRecord(level, msg)
+    r.setParameters(Array(param))
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def log(level: Level, msg: String, params: Array[AnyRef]): Unit = {
+    val r = new LogRecord(level, msg)
+    r.setParameters(params)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def log(level: Level, msg: String, thrown: Throwable): Unit = {
+    val r = new LogRecord(level, msg)
+    r.setThrown(thrown)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def logp(level: Level, sourceClass: String, sourceMethod: String, msg: String): Unit = {
+    val r = new LogRecord(level, msg)
+    r.setSourceClassName(sourceClass)
+    r.setSourceMethodName(sourceMethod)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def logp(level: Level, sourceClass: String, sourceMethod: String,
+      msg: String, param: AnyRef): Unit = {
+    val r = new LogRecord(level, msg)
+    r.setParameters(Array(param))
+    r.setSourceClassName(sourceClass)
+    r.setSourceMethodName(sourceMethod)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def logp(level: Level, sourceClass: String, sourceMethod: String,
+      msg: String, params: Array[AnyRef]): Unit = {
+    val r = new LogRecord(level, msg)
+    r.setParameters(params)
+    r.setSourceClassName(sourceClass)
+    r.setSourceMethodName(sourceMethod)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def logp(level: Level, sourceClass: String, sourceMethod: String,
+      msg: String, thrown: Throwable): Unit = {
+    val r = new LogRecord(level, msg)
+    r.setThrown(thrown)
+    r.setSourceClassName(sourceClass)
+    r.setSourceMethodName(sourceMethod)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  // Not implemented, no resource bundle
+  //def logrb(level: Level, sourceClass: String, sourceMethod: String,
+  //    bundleName: String, msg: String): Unit = ???
+
+  // Not implemented, no resource bundle
+  //def logrb(level: Level, sourceClass: String, sourceMethod: String,
+  //    bundleName: String, msg: String, param: AnyRef): Unit = ???
+
+  // Not implemented, no resource bundle
+  //def logrb(level: Level, sourceClass: String, sourceMethod: String,
+  //    bundleName: String, msg: String, params: Array[AnyRef]): Unit = ???
+
+  // Not implemented, no resource bundle
+  //def logrb(level: Level, sourceClass: String, sourceMethod: String,
+  //    bundleName: String, msg: String, thrown: Throwable): Unit = ???
+
+  def entering(sourceClass: String, sourceMethod: String): Unit = {
+    val r = new LogRecord(Level.FINER, "ENTRY")
+    r.setSourceClassName(sourceClass)
+    r.setSourceMethodName(sourceMethod)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def entering(sourceClass: String, sourceMethod: String, param: AnyRef): Unit = {
+    val r = new LogRecord(Level.FINER, "ENTRY {0}")
+    r.setSourceClassName(sourceClass)
+    r.setSourceMethodName(sourceMethod)
+    r.setParameters(Array(param))
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  private def paramsString(i: Int): String =
+    (0 until i).map(i => s"{$i}").mkString(" ")
+
+  def entering(sourceClass: String, sourceMethod: String, params: Array[AnyRef]): Unit = {
+    val r = new LogRecord(Level.FINER, s"ENTRY ${paramsString(params.length)}")
+    r.setSourceClassName(sourceClass)
+    r.setSourceMethodName(sourceMethod)
+    r.setLoggerName(name)
+    r.setParameters(params)
+    log(r)
+  }
+
+  def exiting(sourceClass: String, sourceMethod: String): Unit = {
+    val r = new LogRecord(Level.FINER, "RETURN")
+    r.setSourceClassName(sourceClass)
+    r.setSourceMethodName(sourceMethod)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def exiting(sourceClass: String, sourceMethod: String, result: AnyRef): Unit = {
+    val r = new LogRecord(Level.FINER, "RETURN {0}")
+    r.setSourceClassName(sourceClass)
+    r.setSourceMethodName(sourceMethod)
+    r.setParameters(Array(result))
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def throwing(sourceClass: String, sourceMethod: String, thrown: Throwable): Unit = {
+    val r = new LogRecord(Level.FINER, "THROW")
+    r.setSourceClassName(sourceClass)
+    r.setSourceMethodName(sourceMethod)
+    r.setThrown(thrown)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def severe(msg: String): Unit = {
+    val r = new LogRecord(Level.SEVERE, msg)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def warning(msg: String): Unit = {
+    val r = new LogRecord(Level.WARNING, msg)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def info(msg: String): Unit = {
+    val r = new LogRecord(Level.INFO, msg)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def config(msg: String): Unit = {
+    val r = new LogRecord(Level.CONFIG, msg)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def fine(msg: String): Unit = {
+    val r = new LogRecord(Level.FINE, msg)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def finer(msg: String): Unit = {
+    val r = new LogRecord(Level.FINER, msg)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def finest(msg: String): Unit = {
+    val r = new LogRecord(Level.FINEST, msg)
+    r.setLoggerName(name)
+    log(r)
+  }
+
+  def setLevel(newLevel: Level): Unit = this.level = newLevel
+
+  def getLevel(): Level = level
+
+  def getName(): String = name
+
+  def isLoggable(level: Level): Boolean = {
+    val effectiveLevel = levelR
+    effectiveLevel == null || effectiveLevel.intValue() <= level.intValue()
+  }
+
+  def addHandler(handler: Handler): Unit = handlers = handlers :+ handler
+
+  def removeHandler(handler: Handler): Unit =
+    handlers = handlers.filterNot(_ == handler)
+
+  def getHandlers(): Array[Handler] = handlers
+
+  def setUseParentHandlers(useParentHandlers: Boolean): Unit =
+    this.useParentsHandlers = useParentHandlers
+
+  def getUseParentHandlers(): Boolean = useParentsHandlers
+
+  def getParent(): Logger = Logger.findParent(this).getOrElse(parent)
+
+  def setParent(parent: Logger): Unit = this.parent = parent
+}

--- a/src/main/scala/java/util/logging/SimpleFormatter.scala
+++ b/src/main/scala/java/util/logging/SimpleFormatter.scala
@@ -1,0 +1,21 @@
+package java.util.logging
+
+import java.util.Date
+
+class SimpleFormatter extends Formatter {
+  // The default format is implementation specific
+  private val defaultFmt = "[%4$s] %1s - %3$s - %5$s"
+
+  def format(record: LogRecord): String = {
+    // As per spec we check the property or use a default
+    val fmt =
+      System.getProperty("java.util.logging.SimpleFormatter.format", defaultFmt)
+
+    String.format(fmt, new Date(record.getMillis),
+        Option(record.getSourceClassName).getOrElse(""),
+        Option(record.getLoggerName).getOrElse(""),
+        record.getLevel,
+        formatMessage(record),
+        record.getThrown)
+  }
+}

--- a/src/main/scala/java/util/logging/StreamHandler.scala
+++ b/src/main/scala/java/util/logging/StreamHandler.scala
@@ -1,0 +1,79 @@
+package java.util.logging
+
+import java.io.OutputStream
+import java.nio.charset.Charset
+
+class StreamHandler(private[this] var out: OutputStream,
+    private[this] val formatter: Formatter) extends Handler {
+
+  // Defaults defined on javadocs
+  setLevel(Level.INFO)
+  setFilter(null)
+
+  if (formatter == null) setFormatter(new SimpleFormatter())
+  else setFormatter(formatter)
+
+  // Required by javadoc but it is unspecified what to do if formatter is null
+  def this() = this(null, null)
+
+  private[this] var headWritten: Boolean = false
+
+  private def encodingOrDefault: Charset =
+    if (getEncoding == null) Charset.defaultCharset()
+    else Charset.forName(getEncoding)
+
+  protected def setOutputStream(out: OutputStream): Unit = {
+    // Required by javadocs
+    if (out != null && formatter != null) {
+      out.write(formatter.getTail(this).getBytes(encodingOrDefault))
+      flush()
+      out.close()
+    }
+    this.headWritten = false
+    this.out = out
+  }
+
+  // Mentioned as part of StreamHandler javadocs but it doesn't specify behavior
+  override def setEncoding(encoding: String): Unit = super.setEncoding(encoding)
+
+  private def write(c: Formatter => String): Unit = {
+    // The javadocs don't specify what to do if the formatter is null
+    if (out != null && formatter != null) {
+      out.write(c(formatter).getBytes(encodingOrDefault))
+      flush()
+    }
+  }
+
+  private[logging] def writeHeader(): Unit = {
+    if (!headWritten) {
+      write(_.getHead(this))
+      headWritten = true
+    }
+  }
+
+  private[logging] def writeTail(): Unit = write(_.getTail(this))
+
+  override def publish(record: LogRecord): Unit = {
+    writeHeader()
+    // The javadocs don't specify what to do if the formatter is null
+    if (out != null && formatter != null && isLoggable(record)) {
+      out.write(formatter.format(record).getBytes(encodingOrDefault))
+      flush()
+    }
+  }
+
+  override def isLoggable(record:LogRecord): Boolean =
+    out != null && record != null && super.isLoggable(record)
+
+  override def flush(): Unit = if (out != null) out.flush()
+
+  override def close(): Unit = {
+    if (out != null) {
+      // Required by javadocs
+      writeHeader()
+      writeTail()
+      flush()
+      out.close()
+    }
+  }
+}

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/logging/DummyTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/logging/DummyTest.scala
@@ -1,7 +1,0 @@
-package org.scalajs.testsuite.javalib.logging
-
-import org.junit.Test
-
-class DummyTest {
-  @Test def test(): Unit = ()
-}

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/HandlerTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/HandlerTest.scala
@@ -1,0 +1,126 @@
+package org.scalajs.testsuite.javalib.util.logging
+
+import java.util.logging._
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalajs.testsuite.utils.Platform
+import org.scalajs.testsuite.utils.AssertThrows._
+
+class HandlerTest {
+  class TestHandler extends Handler {
+    override def flush(): Unit = {}
+
+    override def publish(record: LogRecord): Unit = {}
+
+    override def close(): Unit = {}
+
+    override def reportError(msg: String, ex: Exception, code: Int): Unit =
+      super.reportError(msg, ex, code)
+  }
+
+  class TestFilter(allow: Boolean) extends Filter {
+    override def isLoggable(record: LogRecord): Boolean = allow
+  }
+
+  class TestErrorManager extends ErrorManager {
+    var callParams: Option[(String, Exception, Int)] = None
+
+    override def error(msg: String, ex: Exception, code: Int): Unit =
+      callParams = Some((msg, ex, code))
+  }
+
+  @Test def test_constructor(): Unit = {
+    val h = new TestHandler()
+    assertNull(h.getFormatter)
+    assertNull(h.getEncoding)
+    assertNull(h.getFilter)
+    assertNotNull(h.getErrorManager)
+    assertEquals(Level.ALL, h.getLevel)
+
+    h.setFormatter(new SimpleFormatter())
+    assertNotNull(h.getFormatter)
+    // The javadocs indicate this is allowed but at runtime on
+    // the JVM an NPE is thrown
+    if (!Platform.executingInJVM) {
+      h.setFormatter(null)
+      assertNull(h.getFormatter)
+    }
+
+    h.setFilter(new TestFilter(true))
+    assertNotNull(h.getFilter)
+    h.setFilter(null)
+    assertNull(h.getFilter)
+
+    h.setEncoding("UTF-16")
+    assertNotNull(h.getEncoding)
+    h.setEncoding(null)
+    assertNull(h.getEncoding)
+
+    expectThrows(classOf[NullPointerException], h.setErrorManager(null))
+
+    h.setLevel(Level.FINE)
+    assertEquals(Level.FINE, h.getLevel)
+    expectThrows(classOf[NullPointerException], h.setLevel(null))
+  }
+
+  @Test def test_report_error(): Unit = {
+    // Error manager is quite opaque, to test we'll use a mock version
+    // to record the params
+    val h = new TestHandler()
+    val e = new TestErrorManager()
+    h.setErrorManager(e)
+    val ex = new RuntimeException()
+    h.reportError("msg", ex, 24)
+    assertEquals(Some(("msg", ex, 24)), e.callParams)
+  }
+
+  @Test def test_handler_is_loggable(): Unit = {
+    val h1 = new TestHandler()
+
+    def checkLogAllLevels: Unit = {
+      assertTrue(h1.isLoggable(new LogRecord(Level.SEVERE, "message")))
+      assertTrue(h1.isLoggable(new LogRecord(Level.WARNING, "message")))
+      assertTrue(h1.isLoggable(new LogRecord(Level.INFO, "message")))
+      assertTrue(h1.isLoggable(new LogRecord(Level.CONFIG, "message")))
+      assertTrue(h1.isLoggable(new LogRecord(Level.FINE, "message")))
+      assertTrue(h1.isLoggable(new LogRecord(Level.FINER, "message")))
+      assertTrue(h1.isLoggable(new LogRecord(Level.FINEST, "message")))
+      assertTrue(h1.isLoggable(new LogRecord(Level.OFF, "message")))
+      assertTrue(h1.isLoggable(new LogRecord(Level.ALL, "message")))
+    }
+
+    // Level is all at start
+    checkLogAllLevels
+
+    // Check filter
+    h1.setFilter(new TestFilter(true))
+    checkLogAllLevels
+
+    // Check filter
+    h1.setFilter(new TestFilter(false))
+    assertFalse(h1.isLoggable(new LogRecord(Level.SEVERE, "message")))
+    assertFalse(h1.isLoggable(new LogRecord(Level.WARNING, "message")))
+    assertFalse(h1.isLoggable(new LogRecord(Level.INFO, "message")))
+    assertFalse(h1.isLoggable(new LogRecord(Level.CONFIG, "message")))
+    assertFalse(h1.isLoggable(new LogRecord(Level.FINE, "message")))
+    assertFalse(h1.isLoggable(new LogRecord(Level.FINER, "message")))
+    assertFalse(h1.isLoggable(new LogRecord(Level.FINEST, "message")))
+    assertFalse(h1.isLoggable(new LogRecord(Level.OFF, "message")))
+    assertFalse(h1.isLoggable(new LogRecord(Level.ALL, "message")))
+
+    // set it at INFO
+    val h2 = new TestHandler()
+    h2.setLevel(Level.INFO)
+    assertTrue(h2.isLoggable(new LogRecord(Level.SEVERE, "message")))
+    assertTrue(h2.isLoggable(new LogRecord(Level.WARNING, "message")))
+    assertTrue(h2.isLoggable(new LogRecord(Level.INFO, "message")))
+    assertFalse(h2.isLoggable(new LogRecord(Level.CONFIG, "message")))
+    assertFalse(h2.isLoggable(new LogRecord(Level.FINE, "message")))
+    assertFalse(h2.isLoggable(new LogRecord(Level.FINER, "message")))
+    assertFalse(h2.isLoggable(new LogRecord(Level.FINEST, "message")))
+    assertTrue(h2.isLoggable(new LogRecord(Level.OFF, "message")))
+    assertFalse(h2.isLoggable(new LogRecord(Level.ALL, "message")))
+  }
+}

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/LevelTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/LevelTest.scala
@@ -1,0 +1,46 @@
+package org.scalajs.testsuite.javalib.util.logging
+
+import java.util.logging.Level
+
+import org.junit.Assert._
+import org.junit.Test
+
+class LevelTest {
+  @Test def test_static(): Unit = {
+    assertEquals("OFF", Level.OFF.getName)
+    assertEquals(Int.MaxValue, Level.OFF.intValue())
+
+    assertEquals("SEVERE", Level.SEVERE.getName)
+    assertEquals(1000, Level.SEVERE.intValue())
+
+    assertEquals("WARNING", Level.WARNING.getName)
+    assertEquals(900, Level.WARNING.intValue())
+
+    assertEquals("INFO", Level.INFO.getName)
+    assertEquals(800, Level.INFO.intValue())
+
+    assertEquals("CONFIG", Level.CONFIG.getName)
+    assertEquals(700, Level.CONFIG.intValue())
+
+    assertEquals("FINE", Level.FINE.getName)
+    assertEquals(500, Level.FINE.intValue())
+
+    assertEquals("FINER", Level.FINER.getName)
+    assertEquals(400, Level.FINER.intValue())
+
+    assertEquals("FINEST", Level.FINEST.getName)
+    assertEquals(300, Level.FINEST.intValue())
+
+    assertEquals("ALL", Level.ALL.getName)
+    assertEquals(Int.MinValue, Level.ALL.intValue())
+  }
+
+  @Test def test_equals_hash_code(): Unit = {
+    assertEquals(Level.SEVERE, Level.SEVERE)
+    assertSame(Level.SEVERE, Level.SEVERE)
+    assertFalse(Level.SEVERE == Level.WARNING)
+    assertNotSame(Level.SEVERE, Level.WARNING)
+
+    assertEquals(Level.SEVERE.hashCode(), Level.SEVERE.hashCode())
+  }
+}

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/LogRecordTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/LogRecordTest.scala
@@ -1,0 +1,74 @@
+package org.scalajs.testsuite.javalib.util.logging
+
+import java.util.logging.{Level, LogRecord}
+
+import org.junit.Test
+import org.junit.Assert._
+
+class LogRecordTest {
+  @Test def test_constructor(): Unit = {
+    val record = new LogRecord(Level.INFO, "msg")
+
+    assertEquals(Level.INFO, record.getLevel)
+    record.setLevel(Level.FINE)
+    assertEquals(Level.FINE, record.getLevel)
+
+    assertTrue(record.getSequenceNumber >= 0)
+    record.setSequenceNumber(256L)
+    assertEquals(256L, record.getSequenceNumber)
+
+    assertNull(record.getLoggerName)
+    record.setLoggerName("logger")
+    assertEquals("logger", record.getLoggerName)
+    record.setLoggerName(null)
+    assertNull(record.getLoggerName)
+
+    assertNull(record.getSourceClassName)
+    record.setSourceClassName("MyClass")
+    assertEquals("MyClass", record.getSourceClassName)
+    record.setSourceClassName(null)
+    assertNull(record.getSourceClassName)
+
+    assertNull(record.getSourceMethodName)
+    record.setSourceMethodName("method")
+    assertEquals("method", record.getSourceMethodName)
+    record.setSourceMethodName(null)
+    assertNull(record.getSourceMethodName)
+
+    assertEquals("msg", record.getMessage)
+    record.setMessage("newmsg")
+    assertEquals("newmsg", record.getMessage)
+    record.setMessage(null)
+    assertNull(record.getMessage)
+
+    assertNull(record.getParameters)
+    record.setParameters(Array[AnyRef]("value"))
+    assertArrayEquals(Array[AnyRef]("value"), record.getParameters)
+    record.setParameters(null)
+    assertNull(record.getParameters)
+
+    assertEquals(Thread.currentThread().getId, record.getThreadID.toLong)
+    record.setThreadID(5)
+    assertEquals(5L, record.getThreadID.toLong)
+
+    assertTrue(record.getMillis <= System.currentTimeMillis())
+    record.setMillis(1)
+    assertEquals(1L, record.getMillis)
+
+    assertNull(record.getThrown)
+    record.setThrown(new RuntimeException("testmsg"))
+    assertEquals("testmsg", record.getThrown.getMessage)
+    record.setThrown(null)
+    assertNull(record.getThrown)
+  }
+
+  @Test def test_parameter_reference(): Unit = {
+    val params = Array[AnyRef]("abc", "cde")
+    val record = new LogRecord(Level.INFO, "msg")
+    record.setParameters(params)
+
+    // Change the params reference
+    params(0) = "101"
+    assertEquals("101", record.getParameters()(0))
+  }
+}

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/LoggerTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/LoggerTest.scala
@@ -1,0 +1,346 @@
+package org.scalajs.testsuite.javalib.util.logging
+
+import java.util.logging._
+
+import org.junit.{Ignore, Test}
+import org.junit.Assert._
+
+class LoggerTest {
+  // We add a prefix to all loggers. This avoids some errors when running tests
+  // more than once as the loggers are global
+  val prefix = System.currentTimeMillis().toString
+
+  val levels = List(Level.SEVERE, Level.WARNING, Level.INFO, Level.CONFIG,
+      Level.FINE, Level.FINER, Level.FINEST)
+
+  class TestFilter extends Filter {
+    override def isLoggable(record: LogRecord): Boolean = true
+  }
+
+  class TestHandler extends Handler {
+    var lastRecord: LogRecord = null
+
+    override def flush(): Unit = {}
+
+    override def publish(record: LogRecord): Unit = lastRecord = record
+
+    override def close(): Unit = {}
+  }
+
+  @Test def test_global_logger(): Unit = {
+    val logger = Logger.getGlobal
+    assertEquals("global", Logger.GLOBAL_LOGGER_NAME)
+    assertEquals("global", logger.getName)
+    assertTrue(logger.getUseParentHandlers)
+    assertNotNull(logger.getParent)
+  }
+
+  @Test def test_static(): Unit = {
+    assertEquals("global", Logger.GLOBAL_LOGGER_NAME)
+  }
+
+  @Test def test_get_logger(): Unit = {
+    assertEquals(s"$prefix.TestLogger",
+        Logger.getLogger(s"$prefix.TestLogger").getName)
+    // Level comes from the default log
+    assertNull(Logger.getLogger(s"$prefix.TestLogger").getLevel)
+    assertTrue(Logger.getLogger(s"$prefix.TestLogger").getUseParentHandlers)
+    assertNotNull(Logger.getLogger(s"$prefix.TestLogger").getParent)
+  }
+
+  @Test def test_get_anonymous_logger(): Unit = {
+    assertEquals(null, Logger.getAnonymousLogger().getName)
+    // Level comes from the default log
+    assertNull(Logger.getAnonymousLogger().getLevel)
+    assertTrue(Logger.getAnonymousLogger().getUseParentHandlers)
+    assertNotNull(Logger.getAnonymousLogger().getParent)
+  }
+
+  @Test def test_properties(): Unit = {
+    val logger = Logger.getLogger(s"$prefix.TestLogger2")
+    logger.setUseParentHandlers(true)
+    assertTrue(logger.getUseParentHandlers)
+    logger.setUseParentHandlers(false)
+    assertFalse(logger.getUseParentHandlers)
+    assertNull(logger.getResourceBundleName)
+
+    val filter = new TestFilter()
+    logger.setFilter(filter)
+    assertEquals(filter, logger.getFilter)
+
+    logger.setLevel(Level.WARNING)
+    assertEquals(Level.WARNING, logger.getLevel)
+  }
+
+  @Test def test_is_loggable(): Unit = {
+    val logger = Logger.getLogger(s"$prefix.TestLogger3")
+    logger.setLevel(Level.ALL)
+    assertTrue(logger.isLoggable(logger.getLevel))
+
+    assertTrue(levels.forall(logger.isLoggable))
+    logger.setLevel(Level.OFF)
+    assertFalse(levels.exists(logger.isLoggable))
+  }
+
+  @Test def test_is_loggable_inheritance(): Unit = {
+    val logger = Logger.getLogger(s"$prefix.TestLogger4")
+    logger.setLevel(null)
+    logger.getParent.setLevel(Level.ALL)
+
+    assertTrue(levels.forall(logger.isLoggable))
+    logger.getParent.setLevel(Level.OFF)
+    assertFalse(levels.exists(logger.isLoggable))
+  }
+
+  @Test def test_add_remove_handler(): Unit = {
+    val logger = Logger.getLogger(s"$prefix.TestLogger5")
+    assertTrue(logger.getHandlers.isEmpty)
+    val testHandler = new TestHandler
+    logger.addHandler(testHandler)
+    assertTrue(logger.getHandlers.contains(testHandler))
+    logger.removeHandler(testHandler)
+    assertFalse(logger.getHandlers.contains(testHandler))
+  }
+
+  @Test def test_log_record_no_parents_all(): Unit = {
+    val logger = Logger.getLogger(s"$prefix.TestLogger6")
+    val testHandler = new TestHandler
+    logger.setLevel(Level.ALL)
+    logger.addHandler(testHandler)
+    logger.setUseParentHandlers(false)
+
+    val lrFine = new LogRecord(Level.FINE, "Log")
+    logger.log(lrFine)
+    assertEquals(Level.FINE, testHandler.lastRecord.getLevel)
+    assertEquals("Log", testHandler.lastRecord.getMessage)
+  }
+
+  @Test def test_log_record_no_parents_level(): Unit = {
+    val logger = Logger.getLogger(s"$prefix.TestLogger7")
+    val testHandler = new TestHandler
+    logger.setLevel(Level.INFO)
+    logger.addHandler(testHandler)
+    logger.setUseParentHandlers(false)
+
+    val lrFine = new LogRecord(Level.FINE, "Log")
+    logger.log(lrFine)
+    assertNull(testHandler.lastRecord)
+  }
+
+  @Test def test_log_record_use_parents_all(): Unit = {
+    val logger = Logger.getLogger(s"$prefix.TestLogger8")
+    val testHandler = new TestHandler
+    logger.getParent.setLevel(Level.ALL)
+    logger.getParent.addHandler(testHandler)
+    logger.setUseParentHandlers(true)
+
+    val lrFine = new LogRecord(Level.FINE, "Log")
+    logger.log(lrFine)
+    assertEquals(Level.FINE, testHandler.lastRecord.getLevel)
+    assertEquals("Log", testHandler.lastRecord.getMessage)
+  }
+
+  @Test def test_log_record_use_parents_local_off(): Unit = {
+    val logger = Logger.getLogger(s"$prefix.TestLogger9")
+    val testHandler = new TestHandler
+    logger.setLevel(Level.OFF)
+    logger.getParent.setLevel(Level.ALL)
+    logger.getParent.addHandler(testHandler)
+    logger.setUseParentHandlers(true)
+
+    val lrFine = new LogRecord(Level.FINE, "Log")
+    logger.log(lrFine)
+    assertNull(testHandler.lastRecord)
+  }
+
+  @Test def test_log_record_use_parents_level(): Unit = {
+    val logger = Logger.getLogger(s"$prefix.TestLogger10")
+    val testHandler = new TestHandler
+    logger.setLevel(Level.OFF)
+    logger.getParent.setLevel(Level.INFO)
+    logger.getParent.addHandler(testHandler)
+    logger.setUseParentHandlers(true)
+
+    val lrFine = new LogRecord(Level.FINE, "Log")
+    logger.log(lrFine)
+    assertNull(testHandler.lastRecord)
+  }
+
+  @Test def test_log_variants(): Unit = {
+    val logger = Logger.getLogger(s"$prefix.TestLogger11")
+    val testHandler = new TestHandler
+    logger.setLevel(Level.ALL)
+    logger.addHandler(testHandler)
+    logger.setUseParentHandlers(false)
+
+    logger.log(Level.FINE, "Log")
+    assertEquals(Level.FINE, testHandler.lastRecord.getLevel)
+    assertEquals("Log", testHandler.lastRecord.getMessage)
+
+    logger.log(Level.FINE, "Log", "param")
+    assertEquals(Level.FINE, testHandler.lastRecord.getLevel)
+    assertEquals("Log", testHandler.lastRecord.getMessage)
+    assertArrayEquals(Array[AnyRef]("param"),
+        testHandler.lastRecord.getParameters)
+
+    logger.log(Level.FINE, "Log", Array[AnyRef]("param1", "param2"))
+    assertEquals(Level.FINE, testHandler.lastRecord.getLevel)
+    assertEquals("Log", testHandler.lastRecord.getMessage)
+    assertArrayEquals(Array[AnyRef]("param1", "param2"),
+        testHandler.lastRecord.getParameters)
+
+    logger.log(Level.FINE, "Log", new RuntimeException())
+    assertEquals(Level.FINE, testHandler.lastRecord.getLevel)
+    assertEquals("Log", testHandler.lastRecord.getMessage)
+    assertNotNull(testHandler.lastRecord.getThrown)
+  }
+
+  @Test def test_logp_variants(): Unit = {
+    val logger = Logger.getLogger(s"$prefix.TestLogger11")
+    val testHandler = new TestHandler
+    logger.setLevel(Level.ALL)
+    logger.addHandler(testHandler)
+    logger.setUseParentHandlers(false)
+
+    logger.logp(Level.FINE, "cls", "method", "Log")
+    assertEquals(Level.FINE, testHandler.lastRecord.getLevel)
+    assertEquals("Log", testHandler.lastRecord.getMessage)
+    assertEquals("cls", testHandler.lastRecord.getSourceClassName)
+    assertEquals("method", testHandler.lastRecord.getSourceMethodName)
+
+    logger.logp(Level.FINE, "cls", "method", "Log", "param")
+    assertEquals(Level.FINE, testHandler.lastRecord.getLevel)
+    assertEquals("Log", testHandler.lastRecord.getMessage)
+    assertArrayEquals(Array[AnyRef]("param"),
+        testHandler.lastRecord.getParameters)
+    assertEquals("cls", testHandler.lastRecord.getSourceClassName)
+    assertEquals("method", testHandler.lastRecord.getSourceMethodName)
+
+    logger.logp(Level.FINE, "cls", "method", "Log",
+        Array[AnyRef]("param1", "param2"))
+    assertEquals(Level.FINE, testHandler.lastRecord.getLevel)
+    assertEquals("Log", testHandler.lastRecord.getMessage)
+    assertArrayEquals(Array[AnyRef]("param1", "param2"),
+        testHandler.lastRecord.getParameters)
+    assertEquals("cls", testHandler.lastRecord.getSourceClassName)
+    assertEquals("method", testHandler.lastRecord.getSourceMethodName)
+
+    logger.logp(Level.FINE, "cls", "method", "Log", new RuntimeException())
+    assertEquals(Level.FINE, testHandler.lastRecord.getLevel)
+    assertEquals("Log", testHandler.lastRecord.getMessage)
+    assertNotNull(testHandler.lastRecord.getThrown)
+    assertEquals("cls", testHandler.lastRecord.getSourceClassName)
+    assertEquals("method", testHandler.lastRecord.getSourceMethodName)
+  }
+
+  @Test def test_entering_variants(): Unit = {
+    val logger = Logger.getLogger(s"$prefix.TestLogger11")
+    val testHandler = new TestHandler
+    logger.setLevel(Level.ALL)
+    logger.addHandler(testHandler)
+    logger.setUseParentHandlers(false)
+
+    logger.entering("cls", "method")
+    assertEquals(Level.FINER, testHandler.lastRecord.getLevel)
+    assertEquals("ENTRY", testHandler.lastRecord.getMessage)
+    assertEquals("cls", testHandler.lastRecord.getSourceClassName)
+    assertEquals("method", testHandler.lastRecord.getSourceMethodName)
+
+    logger.entering("cls", "method", "param")
+    assertEquals(Level.FINER, testHandler.lastRecord.getLevel)
+    assertEquals("ENTRY {0}", testHandler.lastRecord.getMessage)
+    assertEquals("cls", testHandler.lastRecord.getSourceClassName)
+    assertEquals("method", testHandler.lastRecord.getSourceMethodName)
+    assertArrayEquals(Array[AnyRef]("param"),
+        testHandler.lastRecord.getParameters)
+
+    logger.entering("cls", "method", Array[AnyRef]("param1", "param2"))
+    assertEquals(Level.FINER, testHandler.lastRecord.getLevel)
+    assertEquals("ENTRY {0} {1}", testHandler.lastRecord.getMessage)
+    assertEquals("cls", testHandler.lastRecord.getSourceClassName)
+    assertEquals("method", testHandler.lastRecord.getSourceMethodName)
+    assertArrayEquals(Array[AnyRef]("param1", "param2"),
+        testHandler.lastRecord.getParameters)
+  }
+
+  @Test def test_exiting_variants(): Unit = {
+    val logger = Logger.getLogger(s"$prefix.TestLogger12")
+    val testHandler = new TestHandler
+    logger.setLevel(Level.ALL)
+    logger.addHandler(testHandler)
+    logger.setUseParentHandlers(false)
+
+    logger.exiting("cls", "method")
+    assertEquals(Level.FINER, testHandler.lastRecord.getLevel)
+    assertEquals("RETURN", testHandler.lastRecord.getMessage)
+    assertEquals("cls", testHandler.lastRecord.getSourceClassName)
+    assertEquals("method", testHandler.lastRecord.getSourceMethodName)
+
+    logger.exiting("cls", "method", "param")
+    assertEquals(Level.FINER, testHandler.lastRecord.getLevel)
+    assertEquals("RETURN {0}", testHandler.lastRecord.getMessage)
+    assertEquals("cls", testHandler.lastRecord.getSourceClassName)
+    assertEquals("method", testHandler.lastRecord.getSourceMethodName)
+    assertArrayEquals(Array[AnyRef]("param"),
+        testHandler.lastRecord.getParameters)
+  }
+
+  @Test def test_throwing(): Unit = {
+    val logger = Logger.getLogger(s"$prefix.TestLogger13")
+    val testHandler = new TestHandler
+    logger.setLevel(Level.ALL)
+    logger.addHandler(testHandler)
+    logger.setUseParentHandlers(false)
+
+    logger.throwing("cls", "method", new RuntimeException)
+    assertEquals(Level.FINER, testHandler.lastRecord.getLevel)
+    assertEquals("THROW", testHandler.lastRecord.getMessage)
+    assertEquals("cls", testHandler.lastRecord.getSourceClassName)
+    assertEquals("method", testHandler.lastRecord.getSourceMethodName)
+    assertNotNull(testHandler.lastRecord.getThrown)
+  }
+
+  @Test def test_named_levels(): Unit = {
+    val logger = Logger.getLogger(s"$prefix.TestLogger13")
+    val testHandler = new TestHandler
+    logger.setLevel(Level.ALL)
+    logger.addHandler(testHandler)
+    logger.setUseParentHandlers(false)
+
+    logger.severe("severe_msg")
+    assertEquals(Level.SEVERE, testHandler.lastRecord.getLevel)
+    assertEquals("severe_msg", testHandler.lastRecord.getMessage)
+
+    logger.warning("warning_msg")
+    assertEquals(Level.WARNING, testHandler.lastRecord.getLevel)
+    assertEquals("warning_msg", testHandler.lastRecord.getMessage)
+
+    logger.info("info_msg")
+    assertEquals(Level.INFO, testHandler.lastRecord.getLevel)
+    assertEquals("info_msg", testHandler.lastRecord.getMessage)
+
+    logger.config("config_msg")
+    assertEquals(Level.CONFIG, testHandler.lastRecord.getLevel)
+    assertEquals("config_msg", testHandler.lastRecord.getMessage)
+
+    logger.fine("fine_msg")
+    assertEquals(Level.FINE, testHandler.lastRecord.getLevel)
+    assertEquals("fine_msg", testHandler.lastRecord.getMessage)
+
+    logger.finer("finer_msg")
+    assertEquals(Level.FINER, testHandler.lastRecord.getLevel)
+    assertEquals("finer_msg", testHandler.lastRecord.getMessage)
+
+    logger.finest("finest_msg")
+    assertEquals(Level.FINEST, testHandler.lastRecord.getLevel)
+    assertEquals("finest_msg", testHandler.lastRecord.getMessage)
+  }
+
+  @Test def test_logger_parents_by_name(): Unit = {
+    val l1 = Logger.getLogger(s"$prefix.a.b.c.d")
+    assertEquals("", l1.getParent.getName)
+
+    val l2 = Logger.getLogger(s"$prefix.a.b")
+    assertEquals(l2.getName, l1.getParent.getName)
+  }
+}

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/SimpleFormatterTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/SimpleFormatterTest.scala
@@ -1,0 +1,69 @@
+package org.scalajs.testsuite.javalib.util.logging
+
+import java.util.logging.{Level, LogRecord, SimpleFormatter}
+
+import org.junit.{Before, Test}
+import org.junit.Assert._
+
+import org.scalajs.testsuite.utils.Platform
+
+class SimpleFormatterTest {
+  @Before def clearProperties():Unit = {
+    System.clearProperty("java.util.logging.SimpleFormatter.format")
+  }
+
+  @Test def test_default_format(): Unit = {
+    val f = new SimpleFormatter()
+    val r = new LogRecord(Level.INFO, "message")
+    r.setLoggerName("logger")
+    assertTrue(f.format(r).contains("message"))
+    assertTrue(f.format(r).contains("logger"))
+  }
+
+  @Test def test_format_with_params(): Unit = {
+    val f = new SimpleFormatter()
+    val msg = "message with params {0} {1}"
+    val r = new LogRecord(Level.INFO, msg)
+    assertTrue(f.format(r).contains(msg))
+
+    val r1 = new LogRecord(Level.INFO, msg)
+    r1.setParameters(Array("param1"))
+    assertTrue(f.format(r1).contains("message with params param1 {1}"))
+
+    val r2 = new LogRecord(Level.INFO, msg)
+    r2.setParameters(Array("param1", new java.lang.Integer(20)))
+    assertTrue(f.format(r2).contains("message with params param1 20"))
+
+    // Bogus cases
+    val r3 = new LogRecord(Level.INFO, "message with params {0} {abc}")
+    r3.setParameters(Array("param1", "test"))
+    assertTrue(f.format(r3).contains("message with params {0} {abc}"))
+
+    val r4 = new LogRecord(Level.INFO, "message with params {0} {{1}}")
+    r4.setParameters(Array("param1", "test"))
+    assertTrue(f.format(r4).contains("message with params {0} {{1}}"))
+
+    val r5 = new LogRecord(Level.INFO, "message with params {0} {{1}")
+    r5.setParameters(Array("param1", "test"))
+    assertTrue(f.format(r5).contains("message with params {0} {{1}"))
+
+    val r6 = new LogRecord(Level.INFO, "message with params {0} {-1}")
+    r6.setParameters(Array("param1", "test"))
+    assertTrue(f.format(r6).contains("message with params {0} {-1}"))
+
+    val r7 = new LogRecord(Level.INFO, "message with params {0} {1")
+    r7.setParameters(Array("param1", "test"))
+    assertTrue(f.format(r7).contains("message with params {0} {1"))
+  }
+
+  @Test def test_format_property(): Unit = {
+    System.setProperty("java.util.logging.SimpleFormatter.format", "%3$s - %5$s")
+    val f = new SimpleFormatter()
+    val r = new LogRecord(Level.INFO, "message")
+    r.setLoggerName("logger")
+    // The JVM has a different logic for formatting though the javadocs
+    // indicate that the property above should be used
+    if (!Platform.executingInJVM)
+      assertEquals("logger - message", f.format(r))
+  }
+}

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/StreamHandlerTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/StreamHandlerTest.scala
@@ -1,0 +1,84 @@
+package org.scalajs.testsuite.javalib.util.logging
+
+import java.io.ByteArrayOutputStream
+import java.util.logging._
+
+import org.junit.Test
+import org.junit.Assert._
+
+class StreamHandlerTest {
+  object TestFormatter extends SimpleFormatter {
+    override def getHead(h: Handler): String = "header"
+
+    override def getTail(h: Handler): String = "footer"
+  }
+
+  @Test def test_logging():Unit = {
+    val o = new ByteArrayOutputStream()
+    val sh = new StreamHandler(o, new SimpleFormatter())
+    sh.publish(new LogRecord(Level.INFO, "message"))
+    sh.flush()
+    assertTrue(o.toString.contains("message"))
+  }
+
+  @Test def test_default_level():Unit = {
+    val o = new ByteArrayOutputStream()
+    val sh = new StreamHandler(o, new SimpleFormatter())
+    // Defaults to level INFO
+    sh.publish(new LogRecord(Level.FINER, "message"))
+    sh.flush()
+    assertFalse(o.toString.contains("message"))
+  }
+
+  @Test def test_default_config():Unit = {
+    val o = new ByteArrayOutputStream()
+    val sh = new StreamHandler(o, new SimpleFormatter())
+    assertNull(sh.getEncoding)
+    assertNull(sh.getFilter)
+    assertNotNull(sh.getFormatter)
+    assertNotNull(sh.getErrorManager)
+  }
+
+  @Test def test_default_constructor_config():Unit = {
+    val sh = new StreamHandler()
+    assertNull(sh.getEncoding)
+    assertNull(sh.getFilter)
+    assertNotNull(sh.getFormatter)
+    assertNotNull(sh.getErrorManager)
+  }
+
+  @Test def test_no_logging_for_level():Unit = {
+    val o = new ByteArrayOutputStream()
+    val sh = new StreamHandler(o, new SimpleFormatter())
+    sh.setLevel(Level.WARNING)
+    sh.publish(new LogRecord(Level.INFO, "message"))
+    sh.flush()
+    // No output under the given level
+    assertTrue(o.toString.isEmpty)
+  }
+
+  @Test def test_no_errors_if_no_stream():Unit = {
+    val sh = new StreamHandler()
+    sh.publish(new LogRecord(Level.INFO, "message"))
+    sh.flush()
+  }
+
+  @Test def test_print_head():Unit = {
+    val o = new ByteArrayOutputStream()
+    val sh = new StreamHandler(o, TestFormatter)
+    assertTrue(o.toString.isEmpty)
+    sh.publish(new LogRecord(Level.INFO, "message"))
+    sh.flush()
+    assertTrue(o.toString.contains("header"))
+    assertTrue(!o.toString.contains("footer"))
+  }
+
+  @Test def test_print_tail():Unit = {
+    val o = new ByteArrayOutputStream()
+    val sh = new StreamHandler(o, TestFormatter)
+    assertTrue(o.toString.isEmpty)
+    sh.close()
+    assertTrue(o.toString.contains("header"))
+    assertTrue(o.toString.contains("footer"))
+  }
+}


### PR DESCRIPTION
This PR contains an implementation of large part of the java util logging package. This PR was submitted to scala-js as scala-js/scala-js#2410
