### PR TITLE
Set parent logger reference upon initialization

### DIFF
--- a/src/main/scala/java/util/logging/Logger.scala
+++ b/src/main/scala/java/util/logging/Logger.scala
@@ -41,18 +41,20 @@ object Logger {
     logger.setLevel(null)
     logger.setUseParentHandlers(true)
     logger.setParent(findParentLoggerOf(name))
-    updateChildLoggerParent(logger)
+    if (name != null) {
+      updateChildLoggerParent(logger)
+    }
     logger
   }
 
-  private def updateChildLoggerParent(parent:Logger): Unit ={
-    val prefix = s"${parent.getName}."
-    for((name, l) <- loggers if name.startsWith(prefix)) {
+  private def updateChildLoggerParent(newParent:Logger): Unit ={
+    val prefix = s"${newParent.getName}."
+    for ((name, l) <- loggers if name.startsWith(prefix)) {
       val currentParent = l.getParent
       // For example, if a new parent is a.b and the child is a.b.c.d,
       // unless the current parent is a.b.c, we need to update the parent
-      if(currentParent == null || !currentParent.getName.startsWith(prefix)) {
-        l.setParent(parent)
+      if (currentParent == null || !currentParent.getName.startsWith(prefix)) {
+        l.setParent(newParent)
       }
     }
   }

--- a/src/main/scala/java/util/logging/Logger.scala
+++ b/src/main/scala/java/util/logging/Logger.scala
@@ -24,7 +24,6 @@ object Logger {
       case ROOT_LOGGER_NAME =>
         null
       case _ =>
-        val parentNodes = name.split("\\.").toList.dropRight(1)
         val parentName = name.substring(0, name.lastIndexOf('.').max(0))
         loggers.get(parentName) match {
           case Some(l) => l

--- a/src/main/scala/java/util/logging/Logger.scala
+++ b/src/main/scala/java/util/logging/Logger.scala
@@ -45,11 +45,12 @@ object Logger {
 
   private def updateChildLoggerParent(newParent: Logger): Unit ={
     val prefix = s"${newParent.getName}."
+    // Traverse all child loggers of the new parent
     for ((name, childLogger) <- loggers if name.startsWith(prefix)) {
       val currentParent = childLogger.getParent
-      // For example, when a new parent is a.b:
-      // - if child a.b.c.d (parent = null) => needs to be a.b.c.d (parent = a.b)
-      // - if child a.b.c.e (parent = a.b.c) => no update is required.
+      // For example, when a new parent a.b is added:
+      // - if child is a.b.c.d (parent = null) => needs to be a.b.c.d (parent = a.b)
+      // - if child is a.b.c.e (parent = a.b.c) => no update is required.
       if (currentParent == null || !currentParent.getName.startsWith(prefix)) {
         childLogger.setParent(newParent)
       }

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/LoggerTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/LoggerTest.scala
@@ -5,6 +5,8 @@ import java.util.logging._
 import org.junit.{Ignore, Test}
 import org.junit.Assert._
 
+import scala.annotation.tailrec
+
 class LoggerTest {
   // We add a prefix to all loggers. This avoids some errors when running tests
   // more than once as the loggers are global
@@ -337,10 +339,38 @@ class LoggerTest {
   }
 
   @Test def test_logger_parents_by_name(): Unit = {
-    val l1 = Logger.getLogger(s"$prefix.a.b.c.d")
-    assertEquals("", l1.getParent.getName)
+    val loggerName = s"${prefix}.a.b.c.d}"
+    var l1 = Logger.getLogger(loggerName)
+    val p1 = l1.getParent
 
-    val l2 = Logger.getLogger(s"$prefix.a.b")
-    assertEquals(l2.getName, l1.getParent.getName)
+    // l1's parent should be the root logger
+    val r = Logger.getLogger("")
+    assertEquals(p1.getName, r.getName)
+    assertSame(p1, r)
+
+    // Add a logger in between root and l1
+    val l2 = Logger.getLogger(s"${prefix}.a.b")
+    // l1's parent should be l2
+    val p2 = l1.getParent
+    assertEquals(l2.getName, p2.getName)
+    assertSame(l2, p2)
+  }
+
+  @Test def test_single_root(): Unit = {
+    val l1 = Logger.getLogger(s"${prefix}.test1")
+    val l2 = Logger.getLogger(s"${prefix}.test2.a")
+
+    @tailrec
+    def findRoot(l:Logger): Logger = l.getParent match {
+      case null => l
+      case other => findRoot(l.getParent)
+    }
+
+    val r1 = findRoot(l1)
+    val r2 = findRoot(l2)
+    val r = Logger.getLogger("")
+    assertSame(r1, r2)
+    assertSame(r1, r)
+    assertSame(r2, r)
   }
 }

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/LoggerTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/LoggerTest.scala
@@ -56,6 +56,10 @@ class LoggerTest {
     assertNull(Logger.getAnonymousLogger().getLevel)
     assertTrue(Logger.getAnonymousLogger().getUseParentHandlers)
     assertNotNull(Logger.getAnonymousLogger().getParent)
+
+    // Sanity test of getAnonymousLogger after adding a new logger
+    val logger = Logger.getLogger(s"$prefix.a")
+    Logger.getAnonymousLogger()
   }
 
   @Test def test_properties(): Unit = {

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/LoggerTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/LoggerTest.scala
@@ -343,7 +343,7 @@ class LoggerTest {
   }
 
   @Test def test_logger_parents_by_name(): Unit = {
-    val loggerName = s"${prefix}.a.b.c.d}"
+    val loggerName = s"${prefix}.a.b.c.d"
     var l1 = Logger.getLogger(loggerName)
     val p1 = l1.getParent
 
@@ -365,8 +365,8 @@ class LoggerTest {
     val l2 = Logger.getLogger(s"${prefix}.test2.a")
 
     @tailrec
-    def findRoot(l:Logger): Logger = l.getParent match {
-      case null => l
+    def findRoot(l: Logger): Logger = l.getParent match {
+      case null  => l
       case other => findRoot(l.getParent)
     }
 


### PR DESCRIPTION
This PR:
 - [X] Removes findParent method, which happens to create multiple root loggers with the empty name `""`
 - [X] Instead added `prepareParentLoggerOf(name)` to ensure creating and registering the parent loggers in advance. This also reduces the overhead of resolving parent loggers