### PR TITLE
Recursively call parent handlers when child is loggable

### DIFF
--- a/src/main/scala/java/util/logging/Logger.scala
+++ b/src/main/scala/java/util/logging/Logger.scala
@@ -117,14 +117,19 @@ class Logger(name: String, resourceBundle: String) {
 
   def getFilter(): Filter = filter
 
+  private[Logger] def publish(record: LogRecord): Unit = {
+    if (useParentsHandlers) {
+      val parent = getParent()
+      if (parent != null) {
+        parent.publish(record)
+      }
+    }
+    handlers.foreach(_.publish(record))
+  }
+
   def log(record: LogRecord): Unit = {
     if (isLoggable(record.getLevel)) {
-      if (useParentsHandlers) {
-        val parent = getParent()
-        if (parent != null)
-          parent.log(record)
-      }
-      handlers.foreach(_.publish(record))
+      publish(record)
     }
   }
 

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/LoggerTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/logging/LoggerTest.scala
@@ -377,4 +377,34 @@ class LoggerTest {
     assertSame(r1, r)
     assertSame(r2, r)
   }
+
+  @Test def test_parent_logger_handler(): Unit = {
+    val a = Logger.getLogger(s"$prefix.a")
+    a.setLevel(Level.INFO)
+    val handlerA = new TestHandler
+    a.addHandler(handlerA)
+
+    val b = Logger.getLogger(s"$prefix.a.b")
+    a.setLevel(Level.INFO)
+    val handlerB = new TestHandler
+    b.addHandler(handlerB)
+
+    val child = Logger.getLogger(s"$prefix.a.b.c")
+    child.setLevel(Level.INFO)
+    child.fine("fine_msg")
+
+    // a(INFO) -> b(INFO) -> c(INFO)
+    // No FINE log level message should be reported because its parent and ancestor level is INFO
+    assertNull(handlerA.lastRecord)
+    assertNull(handlerB.lastRecord)
+
+    // a(INFO) -> b(INFO) -> c(FINE)
+    child.setLevel(Level.FINE)
+    child.fine("fine_msg2")
+
+    assertNotNull(handlerA.lastRecord)
+    assertEquals("fine_msg2", handlerA.lastRecord.getMessage)
+    assertNotNull(handlerB.lastRecord)
+    assertEquals("fine_msg2", handlerB.lastRecord.getMessage)
+  }
 }


### PR DESCRIPTION
This PR fixes a bug which discards logs even if a child logger has a finer loglevel than the parent level.

For example, when we have a parent logger (INFO) and its child logger (FINE or finer), in the current code, calling log.fine(msg) of the child logger will bypass the request to parent.log(FINE, msg). But this log message will be ignored because the parent log level is INFO. 

So instead of calling `parent.log`, we should call the parent handler's `publish` method.

