### PR TITLE
Support Scala Native

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 .js
 .native
+lowered.hnir

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target/
+.js
+.native

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,23 +9,17 @@ script:
 scala:
   - 2.10.7
   - 2.11.12
-  - 2.12.6
-  - 2.13.0-M3
-  - 2.13.0-M4
+  - 2.12.10
+  - 2.13.1
 jdk:
   - openjdk8
 env:
-  - SCALAJS_VERSION=0.6.23
-  - SCALAJS_VERSION=1.0.0-M3
-  - SCALAJS_VERSION=1.0.0-M5
+  - SCALAJS_VERSION=0.6.29
+  - SCALAJS_VERSION=1.0.0-M8
 matrix:
   exclude:
     - scala: 2.10.7
-      env: SCALAJS_VERSION=1.0.0-M3
-    - scala: 2.13.0-M4
-      env: SCALAJS_VERSION=1.0.0-M3
-    - scala: 2.10.7
-      env: SCALAJS_VERSION=1.0.0-M5
+      env: SCALAJS_VERSION=1.0.0-M8
   include:
     - scala: 2.11.12
       jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ scala:
   - 2.13.0-M3
   - 2.13.0-M4
 jdk:
-  - oraclejdk8
+  - openjdk8
 env:
   - SCALAJS_VERSION=0.6.23
   - SCALAJS_VERSION=1.0.0-M3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: false
 language: scala
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION root/scalastyle testSuiteJVM/scalastyle testSuiteJVM/test:scalastyle testSuiteJS/scalastyle testSuiteJS/test:scalastyle
+  - sbt ++$TRAVIS_SCALA_VERSION rootJS/scalastyle testSuiteJVM/scalastyle testSuiteJVM/test:scalastyle testSuiteJS/scalastyle testSuiteJS/test:scalastyle
   - sbt ++$TRAVIS_SCALA_VERSION testSuiteJVM/test
   - sbt ++$TRAVIS_SCALA_VERSION testSuiteJS/test
   - sbt ++$TRAVIS_SCALA_VERSION 'set scalaJSStage in Global := FullOptStage' testSuiteJS/test
-  - sbt ++$TRAVIS_SCALA_VERSION publishLocal
+  - sbt ++$TRAVIS_SCALA_VERSION rootJS/publishLocal
 scala:
   - 2.10.7
   - 2.11.12
@@ -26,12 +26,30 @@ matrix:
       env: SCALAJS_VERSION=1.0.0-M3
     - scala: 2.10.7
       env: SCALAJS_VERSION=1.0.0-M5
-
-cache:
+  include:
+    - scala: 2.11.12
+      jdk: openjdk8
+      env:
+      - SCALA_NATIVE_VERSION="0.3.9"
+      sudo: required
+      before_install:
+      - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -
+      script:
+      - sbt "++$TRAVIS_SCALA_VERSION!" nativeTestSuite/test rootNative/publishLocal
+    - scala: 2.11.12
+      jdk: openjdk8
+      env:
+      - SCALA_NATIVE_VERSION="0.4.0-M2"
+      sudo: required
+      before_install:
+      - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -
+      script:
+      - sbt "++$TRAVIS_SCALA_VERSION!" nativeTestSuite/test rootNative/publishLocal
+  cache:
   directories:
-    - "$HOME/.ivy2/cache"
+    - "$HOME/.cache/coursier/v1"
     - "$HOME/.sbt"
 before_cache:
   # Cleanup the cached directories to avoid unnecessary cache updates
-  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.coursier -name "*.lock" | xargs rm
   - find $HOME/.sbt -name "*.lock" -print -delete

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,18 @@
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
+val scala210 = "2.10.7"
+val scala211 = "2.11.12"
+val scala212 = "2.12.10"
+val scala213 = "2.13.1"
+
 crossScalaVersions in ThisBuild := {
-  val allVersions = Seq("2.12.10", "2.11.12", "2.10.7", "2.13.1")
+  val allVersions = Seq(scala210, scala211, scala212, scala213)
   if (scalaJSVersion.startsWith("0.6."))
     allVersions
-  else if (scalaJSVersion == "1.0.0-M3")
-    allVersions.filter(v => !v.startsWith("2.10.") && v != "2.13.0-M4")
   else
-    allVersions.filter(!_.startsWith("2.10."))
+    allVersions.filter(_ != scala210)
 }
-scalaVersion in ThisBuild := (crossScalaVersions in ThisBuild).value.head
+scalaVersion in ThisBuild := scala212
 
 val commonSettings: Seq[Setting[_]] = Seq(
   version := "0.1.6-SNAPSHOT",
@@ -26,8 +29,8 @@ val commonSettings: Seq[Setting[_]] = Seq(
 )
 
 val nativeSettings = Seq(
-  scalaVersion := "2.11.12",
-  crossScalaVersions := Seq("2.11.12"),
+  scalaVersion := scala211,
+  crossScalaVersions := Seq(scala211),
   sources in (Compile,doc) := Seq.empty
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
 crossScalaVersions in ThisBuild := {
-  val allVersions = Seq("2.12.6", "2.11.12", "2.10.7", "2.13.0-M3", "2.13.0-M4")
+  val allVersions = Seq("2.12.10", "2.11.12", "2.10.7", "2.13.1")
   if (scalaJSVersion.startsWith("0.6."))
     allVersions
   else if (scalaJSVersion == "1.0.0-M3")

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,8 @@ val commonSettings: Seq[Setting[_]] = Seq(
 
 val nativeSettings = Seq(
   scalaVersion := "2.11.12",
-  crossScalaVersions := Seq("2.11.12")
+  crossScalaVersions := Seq("2.11.12"),
+  sources in (Compile,doc) := Seq.empty
 )
 
 lazy val root = crossProject(JSPlatform, NativePlatform).

--- a/nativeTestSuite/src/test/scala/Main.scala
+++ b/nativeTestSuite/src/test/scala/Main.scala
@@ -1,0 +1,11 @@
+import java.util.logging._
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    val f = new SimpleFormatter()
+    val r = new LogRecord(Level.INFO, "message")
+    r.setLoggerName("logger")
+    assert(f.format(r).contains("message"))
+    assert(f.format(r).contains("logger"))
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.3.3

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,7 +1,11 @@
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.24")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.29")
+val scalaNativeVersion =
+  Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.3.9")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.5.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % scalaNativeVersion)
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.1")
 
-addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")


### PR DESCRIPTION
This PR cross-compiles the library to Scala Native.
Since Scala Native has no JUnit interface I created a simple `Main.scala` file with a test taken from the `testSuite`
I updated Scala 2.13 milestone versions to 2.13.1 and Scala-js 1.0.0 milestone to 1.0.0-M8 too. If one of these updates is not wanted I can revert it.